### PR TITLE
Add autocomplete role

### DIFF
--- a/lib/MetaCPAN/API.pm
+++ b/lib/MetaCPAN/API.pm
@@ -13,6 +13,7 @@ use URI::Escape 'uri_escape';
 
 with qw/
     MetaCPAN::API::Author
+    MetaCPAN::API::Autocomplete
     MetaCPAN::API::Module
     MetaCPAN::API::POD
     MetaCPAN::API::Release

--- a/lib/MetaCPAN/API/Autocomplete.pm
+++ b/lib/MetaCPAN/API/Autocomplete.pm
@@ -1,0 +1,71 @@
+use strict;
+use warnings;
+package MetaCPAN::API::Autocomplete;
+# ABSTRACT: Autocompletion info for MetaCPAN::API
+
+use Carp;
+use Any::Moose 'Role';
+
+# /search/autocomplete?q={search}
+sub autocomplete {
+    my $self  = shift;
+    my %opts  = @_ ? @_ : ();
+    my $url   = '';
+
+    my $error      = "You have to provide a search term";
+    my $size_error = "The size has to be between 0 and 100";
+
+    %opts or croak $error;
+    $opts{search} && ref $opts{search} eq 'HASH' or croak $error;
+
+    my %extra_opts;
+
+    if ( defined ( my $term = $opts{search}->{query} ) ) {
+        $url           = 'search/autocomplete';
+        $extra_opts{q} = $term;
+
+        my $size = $opts{search}->{size};
+        if ( defined $size && $size >= 0 && $size <= 100 ) {
+            $extra_opts{size} = $size;
+        } else {
+            croak $size_error;
+        }
+    } else {
+        croak $error;
+    }
+
+    return $self->fetch( $url, %extra_opts );
+}
+
+1;
+
+__END__
+
+=head1 DESCRIPTION
+
+This role provides MetaCPAN::API with fetching autocomplete information 
+
+=head1 METHODS
+
+=head2 autocomplete
+
+    my $result = $mcpan->autocomplete( 
+        search => {
+            query => 'Moose',
+        },
+    );
+
+By default, you get 20 results (at maximum). If you need more, you
+can also pass C<size>:
+
+    my $result = $mcpan->autocomplete( 
+        search => {
+            query => 'Moose',
+            size  => 30,
+        },
+    );
+
+There is a hardcoded limit of 100 results (hardcoded in MetaCPAN).
+
+Searches MetaCPAN for autocompletion info.
+

--- a/t/autocomplete.t
+++ b/t/autocomplete.t
@@ -1,0 +1,39 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+use Test::More tests => 6;
+use Test::Fatal;
+use t::lib::Functions;
+
+my $mcpan = mcpan();
+
+isa_ok( $mcpan, 'MetaCPAN::API' );
+can_ok( $mcpan, 'autocomplete'  );
+
+my $errmsg   = qr/^You have to provide a search term/;
+my $size_err = qr/^The size has to be between 0 and 100/;
+
+# missing input
+like(
+    exception { $mcpan->autocomplete },
+    $errmsg,
+    'Missing any information',
+);
+
+# incorrect input
+like(
+    exception { $mcpan->autocomplete( ding => 'dong' ) },
+    $errmsg,
+    'Incorrect input',
+);
+
+my $result = $mcpan->autocomplete( search => { query => 'Moose', size => 10 } );
+ok( $result, 'Got result' );
+
+like (
+    exception { $mcpan->autocomplete( search => { query => 'Moose', size => 109 } ) },
+    $size_err,
+    'Size too big',
+);
+


### PR DESCRIPTION
Hi xsawyerx,

monken recently added autocomplete to the API. The commit bf7b20aa80035e7366bafbfd3f92efc242df125d in my repository adds a role that allows users to query the autocompletion api.
- Renee
