### PR TITLE
Final fixes for releasing

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -6,7 +6,11 @@ copyright_year   = 2011
 
 version = 0.43
 
-[@Basic]
+[Git::GatherDir]
+[@Filter]
+-bundle = @Basic
+-remove = GatherDir
+
 [PodSyntaxTests]
 [PodCoverageTests]
 [Test::Perl::Critic]

--- a/lib/MetaCPAN/API.pm
+++ b/lib/MetaCPAN/API.pm
@@ -125,6 +125,10 @@ sub _build_extra_params {
 
     # if it's deep, JSON encoding needs to be involved
     if (scalar grep { ref } values %extra) {
+        # if this is a deep search query, forgetting
+        # query -> match_all in a common mistake...
+        $extra{query} = { match_all => {} } unless ($extra{query});
+    
         my $query_json = to_json( \%extra, { canonical => 1 } );
         %extra = ( source => $query_json );
     }

--- a/t/rating.t
+++ b/t/rating.t
@@ -26,16 +26,17 @@ like(
     'Incorrect input',
 );
 
-my $result = $mcpan->rating('UC6tqabqR-y3xxZk0tgVXQ');
-ok( $result, 'Got result' );
-
-$result = $mcpan->rating( id => 'UC6tqabqR-y3xxZk0tgVXQ' );
-ok( $result, 'Got result' );
-
-$result = $mcpan->rating(
+my $result = $mcpan->rating(
     search => {
         filter => "distribution:Moose",
         fields => [ "date", "rating" ],
     },
 );
+ok( $result, 'Got result' );
+my $rating_id = $result->{hits}{hits}[0]{_id};
+
+$result = $mcpan->rating($rating_id);
+ok( $result, 'Got result' );
+
+$result = $mcpan->rating( id => $rating_id );
 ok( $result, 'Got result' );


### PR DESCRIPTION
Fix t/rating.t to reverse tests
Add mistake fix for deep queries and missing 'query' item
   (which was failing rating.t test)
Replace GatherDir with Git::GatherDir, since existing Makefile.PL is
  causing dupe errors
