### PR TITLE
Convert from Any::Moose to Moo

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -13,6 +13,7 @@ version = 0.44
 
 [AutoPrereqs]
 skip = ^t::lib::Functions$
+skip = ^MooX::Types::MooseLike::Base$
 
 [ModuleBuild]
 [PodWeaver]
@@ -28,3 +29,6 @@ location = root
 [CheckChangeLog]
 [PkgVersion]
 [Repository]
+[Prereqs]
+Safe::Isa              = 0
+MooX::Types::MooseLike = 0

--- a/dist.ini
+++ b/dist.ini
@@ -14,6 +14,7 @@ version = 0.44
 [AutoPrereqs]
 skip = ^t::lib::Functions$
 
+[Deprecated]
 [PodWeaver]
 [ReadmeFromPod]
 [MetaNoIndex]

--- a/dist.ini
+++ b/dist.ini
@@ -30,4 +30,3 @@ location = root
 [Repository]
 [Prereqs]
 Moo                    = 1.000001
-Safe::Isa              = 0

--- a/dist.ini
+++ b/dist.ini
@@ -13,7 +13,6 @@ version = 0.44
 
 [AutoPrereqs]
 skip = ^t::lib::Functions$
-skip = ^MooX::Types::MooseLike::Base$
 
 [ModuleBuild]
 [PodWeaver]
@@ -32,4 +31,3 @@ location = root
 [Prereqs]
 Moo                    = 1.000001
 Safe::Isa              = 0
-MooX::Types::MooseLike = 0

--- a/dist.ini
+++ b/dist.ini
@@ -14,7 +14,6 @@ version = 0.44
 [AutoPrereqs]
 skip = ^t::lib::Functions$
 
-[ModuleBuild]
 [PodWeaver]
 [ReadmeFromPod]
 [MetaNoIndex]

--- a/dist.ini
+++ b/dist.ini
@@ -30,5 +30,6 @@ location = root
 [PkgVersion]
 [Repository]
 [Prereqs]
+Moo                    = 1.000001
 Safe::Isa              = 0
 MooX::Types::MooseLike = 0

--- a/lib/MetaCPAN/API.pm
+++ b/lib/MetaCPAN/API.pm
@@ -4,8 +4,7 @@ package MetaCPAN::API;
 # ABSTRACT: A comprehensive, DWIM-featured API to MetaCPAN (DEPRECATED)
 
 use Moo;
-use Types::Standard qw<Str ArrayRef>;
-use Sub::Quote;
+use Types::Standard qw<Str ArrayRef InstanceOf>;
 use namespace::autoclean;
 
 use Carp;
@@ -35,11 +34,7 @@ has base_url => (
 
 has ua => (
     is  => 'lazy',
-    isa => quote_sub(q{
-        use Safe::Isa;
-        $_[0]->$_isa('HTTP::Tiny')
-            or die "$_[0] must be an HTTP::Tiny object"
-    }),
+    isa => InstanceOf['HTTP::Tiny'],
 );
 
 has ua_args => (

--- a/lib/MetaCPAN/API.pm
+++ b/lib/MetaCPAN/API.pm
@@ -33,7 +33,9 @@ has base_url => (
 );
 
 has ua => (
-    is  => 'lazy',
+    is  => 'ro',
+    lazy => 1,
+    builder => '_build_ua',
     isa => InstanceOf['HTTP::Tiny'],
 );
 

--- a/lib/MetaCPAN/API.pm
+++ b/lib/MetaCPAN/API.pm
@@ -6,6 +6,7 @@ package MetaCPAN::API;
 use Moo;
 use MooX::Types::MooseLike::Base qw<Str ArrayRef>;
 use Sub::Quote;
+use namespace::autoclean;
 
 use Carp;
 use JSON;

--- a/lib/MetaCPAN/API.pm
+++ b/lib/MetaCPAN/API.pm
@@ -4,7 +4,7 @@ package MetaCPAN::API;
 # ABSTRACT: A comprehensive, DWIM-featured API to MetaCPAN (DEPRECATED)
 
 use Moo;
-use MooX::Types::MooseLike::Base qw<Str ArrayRef>;
+use Types::Standard qw<Str ArrayRef>;
 use Sub::Quote;
 use namespace::autoclean;
 

--- a/lib/MetaCPAN/API.pm
+++ b/lib/MetaCPAN/API.pm
@@ -3,7 +3,9 @@ use warnings;
 package MetaCPAN::API;
 # ABSTRACT: A comprehensive, DWIM-featured API to MetaCPAN (DEPRECATED)
 
-use Any::Moose;
+use Moo;
+use MooX::Types::MooseLike::Base qw<Str ArrayRef>;
+use Sub::Quote;
 
 use Carp;
 use JSON;
@@ -26,19 +28,22 @@ with qw/
 
 has base_url => (
     is      => 'ro',
-    isa     => 'Str',
-    default => 'http://api.metacpan.org/v0',
+    isa     => Str,
+    default => sub{'http://api.metacpan.org/v0'},
 );
 
 has ua => (
-    is         => 'ro',
-    isa        => 'HTTP::Tiny',
-    lazy_build => 1,
+    is  => 'lazy',
+    isa => quote_sub(q{
+        use Safe::Isa;
+        $_[0]->$_isa('HTTP::Tiny')
+            or die "$_[0] must be an HTTP::Tiny object"
+    }),
 );
 
 has ua_args => (
     is      => 'ro',
-    isa     => 'ArrayRef',
+    isa     => ArrayRef,
     default => sub {
         my $version = $MetaCPAN::API::VERSION || 'xx';
         return [ agent => "MetaCPAN::API/$version" ];
@@ -47,7 +52,6 @@ has ua_args => (
 
 sub _build_ua {
     my $self = shift;
-
     return HTTP::Tiny->new( @{ $self->ua_args } );
 }
 

--- a/lib/MetaCPAN/API/Author.pm
+++ b/lib/MetaCPAN/API/Author.pm
@@ -4,7 +4,7 @@ package MetaCPAN::API::Author;
 # ABSTRACT: Author information for MetaCPAN::API
 
 use Carp;
-use Any::Moose 'Role';
+use Moo::Role;
 
 # /author/{author}
 sub author {

--- a/lib/MetaCPAN/API/Author.pm
+++ b/lib/MetaCPAN/API/Author.pm
@@ -5,6 +5,7 @@ package MetaCPAN::API::Author;
 
 use Carp;
 use Moo::Role;
+use namespace::autoclean;
 
 # /author/{author}
 sub author {

--- a/lib/MetaCPAN/API/Autocomplete.pm
+++ b/lib/MetaCPAN/API/Autocomplete.pm
@@ -4,7 +4,7 @@ package MetaCPAN::API::Autocomplete;
 # ABSTRACT: Autocompletion info for MetaCPAN::API
 
 use Carp;
-use Any::Moose 'Role';
+use Moo::Role;
 
 # /search/autocomplete?q={search}
 sub autocomplete {

--- a/lib/MetaCPAN/API/Distribution.pm
+++ b/lib/MetaCPAN/API/Distribution.pm
@@ -4,7 +4,8 @@ package MetaCPAN::API::Distribution;
 # ABSTRACT: Distribution information for MetaCPAN::API
 
 use Carp;
-use Any::Moose 'Role';
+use Moo::Role;
+use namespace::autoclean;
 
 # /distribution/{distribution}
 sub distribution {

--- a/lib/MetaCPAN/API/Favorite.pm
+++ b/lib/MetaCPAN/API/Favorite.pm
@@ -4,7 +4,8 @@ package MetaCPAN::API::Favorite;
 # ABSTRACT: Favorite ++ information for MetaCPAN::API
 
 use Carp;
-use Any::Moose 'Role';
+use Moo::Role;
+use namespace::autoclean;
 
 # /favorite/_search only
 sub favorite {

--- a/lib/MetaCPAN/API/File.pm
+++ b/lib/MetaCPAN/API/File.pm
@@ -4,7 +4,8 @@ package MetaCPAN::API::File;
 # ABSTRACT: File information for MetaCPAN::API
 
 use Carp;
-use Any::Moose 'Role';
+use Moo::Role;
+use namespace::autoclean;
 
 # /module/{module}
 # /file/{author}/{release}/{path}

--- a/lib/MetaCPAN/API/Module.pm
+++ b/lib/MetaCPAN/API/Module.pm
@@ -4,7 +4,7 @@ package MetaCPAN::API::Module;
 # ABSTRACT: Module information for MetaCPAN::API
 
 use Carp;
-use Any::Moose 'Role';
+use Moo::Role;
 
 # /module/{module}
 sub module {

--- a/lib/MetaCPAN/API/Module.pm
+++ b/lib/MetaCPAN/API/Module.pm
@@ -5,6 +5,7 @@ package MetaCPAN::API::Module;
 
 use Carp;
 use Moo::Role;
+use namespace::autoclean;
 
 # /module/{module}
 sub module {

--- a/lib/MetaCPAN/API/POD.pm
+++ b/lib/MetaCPAN/API/POD.pm
@@ -4,7 +4,7 @@ package MetaCPAN::API::POD;
 # ABSTRACT: POD information for MetaCPAN::API
 
 use Carp;
-use Any::Moose 'Role';
+use Moo::Role;
 
 # /pod/{module}
 # /pod/{author}/{release}/{path}

--- a/lib/MetaCPAN/API/POD.pm
+++ b/lib/MetaCPAN/API/POD.pm
@@ -5,6 +5,7 @@ package MetaCPAN::API::POD;
 
 use Carp;
 use Moo::Role;
+use namespace::autoclean;
 
 # /pod/{module}
 # /pod/{author}/{release}/{path}

--- a/lib/MetaCPAN/API/Rating.pm
+++ b/lib/MetaCPAN/API/Rating.pm
@@ -4,7 +4,8 @@ package MetaCPAN::API::Rating;
 # ABSTRACT: Rating information for MetaCPAN::API
 
 use Carp;
-use Any::Moose 'Role';
+use Moo::Role;
+use namespace::autoclean;
 
 # /rating/{id}
 # /rating/_search

--- a/lib/MetaCPAN/API/Release.pm
+++ b/lib/MetaCPAN/API/Release.pm
@@ -5,6 +5,7 @@ package MetaCPAN::API::Release;
 
 use Carp;
 use Moo::Role;
+use namespace::autoclean;
 
 # /release/{distribution}
 # /release/{author}/{release}

--- a/lib/MetaCPAN/API/Release.pm
+++ b/lib/MetaCPAN/API/Release.pm
@@ -4,7 +4,7 @@ package MetaCPAN::API::Release;
 # ABSTRACT: Distribution and releases information for MetaCPAN::API
 
 use Carp;
-use Any::Moose 'Role';
+use Moo::Role;
 
 # /release/{distribution}
 # /release/{author}/{release}

--- a/lib/MetaCPAN/API/Source.pm
+++ b/lib/MetaCPAN/API/Source.pm
@@ -4,7 +4,7 @@ package MetaCPAN::API::Source;
 # ABSTRACT: Source information for MetaCPAN::API
 
 use Carp;
-use Any::Moose 'Role';
+use Moo::Role;
 
 # /source/{author}/{release}/{path}
 sub source {

--- a/lib/MetaCPAN/API/Source.pm
+++ b/lib/MetaCPAN/API/Source.pm
@@ -5,6 +5,7 @@ package MetaCPAN::API::Source;
 
 use Carp;
 use Moo::Role;
+use namespace::autoclean;
 
 # /source/{author}/{release}/{path}
 sub source {

--- a/t/author.t
+++ b/t/author.t
@@ -2,6 +2,7 @@
 use strict;
 use warnings;
 
+use Test::RequiresInternet 'api.metacpan.org' => 80;
 use Test::More tests => 4;
 use Test::Fatal;
 use t::lib::Functions;

--- a/t/autocomplete.t
+++ b/t/autocomplete.t
@@ -2,6 +2,7 @@
 use strict;
 use warnings;
 
+use Test::RequiresInternet 'api.metacpan.org' => 80;
 use Test::More tests => 6;
 use Test::Fatal;
 use t::lib::Functions;

--- a/t/distribution.t
+++ b/t/distribution.t
@@ -2,6 +2,7 @@
 use strict;
 use warnings;
 
+use Test::RequiresInternet 'api.metacpan.org' => 80;
 use Test::More tests => 7;
 use Test::Fatal;
 use t::lib::Functions;

--- a/t/favorite.t
+++ b/t/favorite.t
@@ -2,6 +2,7 @@
 use strict;
 use warnings;
 
+use Test::RequiresInternet 'api.metacpan.org' => 80;
 use Test::More tests => 5;
 use Test::Fatal;
 use t::lib::Functions;

--- a/t/file.t
+++ b/t/file.t
@@ -2,6 +2,7 @@
 use strict;
 use warnings;
 
+use Test::RequiresInternet 'api.metacpan.org' => 80;
 use Test::More tests => 8;
 use Test::Fatal;
 use t::lib::Functions;

--- a/t/module.t
+++ b/t/module.t
@@ -2,6 +2,7 @@
 use strict;
 use warnings;
 
+use Test::RequiresInternet 'api.metacpan.org' => 80;
 use Test::More tests => 4;
 use Test::Fatal;
 use t::lib::Functions;

--- a/t/pod.t
+++ b/t/pod.t
@@ -2,6 +2,7 @@
 use strict;
 use warnings;
 
+use Test::RequiresInternet 'api.metacpan.org' => 80;
 use Test::More tests => 11;
 use Test::Fatal;
 use t::lib::Functions;

--- a/t/release.t
+++ b/t/release.t
@@ -2,6 +2,7 @@
 use strict;
 use warnings;
 
+use Test::RequiresInternet 'api.metacpan.org' => 80;
 use Test::More tests => 6;
 use Test::Fatal;
 use t::lib::Functions;

--- a/t/source.t
+++ b/t/source.t
@@ -2,6 +2,7 @@
 use strict;
 use warnings;
 
+use Test::RequiresInternet 'api.metacpan.org' => 80;
 use Test::More tests => 5;
 use Test::Fatal;
 use t::lib::Functions;


### PR DESCRIPTION
This is a refresh of #18.

I've converted it to use Types::Standard.  namespace::autoclean has been updated to work well with Moo since the last PR, so there was no need to touch that part.  I've also added Test::RequiresInternet to the tests to fix #25.